### PR TITLE
refactor(build): streamline `build.gradle`

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -10,9 +10,9 @@ version = '0.0.3-SNAPSHOT'
 java {
     toolchain {
         languageVersion = JavaLanguageVersion.of(21)
-        withJavadocJar()
-        withSourcesJar()
     }
+    withJavadocJar()
+    withSourcesJar()
 }
 
 repositories {
@@ -29,9 +29,6 @@ dependencies {
 
     // https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-starter-web
     api group: 'org.springframework.boot', name: 'spring-boot-starter-web', version: "${springBootVersion}"
-
-    // https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-configuration-processor
-    compileOnly group: 'org.springframework.boot', name: 'spring-boot-configuration-processor', version: "${springBootVersion}"
 
     // https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-configuration-processor
     compileOnly group: 'org.springframework.boot', name: 'spring-boot-configuration-processor', version: "${springBootVersion}"
@@ -57,7 +54,7 @@ tasks.named('test') {
 
 publishing {
     publications {
-        mavenJava(MavenPublication) {
+        create('maven', MavenPublication) {
             from components.java
             pom {
                 name = 'Thymeleaf Asset Manager'
@@ -80,9 +77,9 @@ publishing {
                 }
 
                 scm {
-                    connection = 'scm:git:git://github.com/yourusername/thymeleaf-asset-dialect.git'
-                    developerConnection = 'scm:git:ssh://github.com:yourusername/thymeleaf-asset-dialect.git'
-                    url = 'https://github.com/yourusername/thymeleaf-asset-dialect/tree/main'
+                    connection = 'scm:git:git://github.com/ascasso/thymeleaf-asset-dialect.git'
+                    developerConnection = 'scm:git:ssh://github.com:ascasso/thymeleaf-asset-dialect.git'
+                    url = 'https://github.com/ascasso/thymeleaf-asset-dialect/tree/main'
                 }
             }
         }
@@ -106,8 +103,10 @@ signing {
     def signingKey = findProperty('signingKey')
     def signingPassword = findProperty('signingPassword')
 
-    useInMemoryPgpKeys(signingKey, signingPassword)
-    sign publishing.publications.mavenJava
+    if (signingKey && signingPassword) {
+        useInMemoryPgpKeys(signingKey as String, signingPassword as String)
+        sign publishing.publications.maven
+    }
 }
 
 tasks.withType(Sign).configureEach {


### PR DESCRIPTION
update publishing configurations

- Restructure `java` block to move `withJavadocJar` and `withSourcesJar` outside `toolchain`.
- Remove duplicate Spring Boot configuration processor dependency.
- Rename Maven publication to `maven` and adjust associated signing logic.
- Update SCM information with the correct repository URL.
- Add null checks for signing configuration to improve robustness.